### PR TITLE
Add CODEOWNERS file and update .gitignore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# CODEOWNERS file for audio_snippet_automation
+#
+# This file defines who should be automatically requested for review
+# when changes are made to specific files or directories.
+#
+# Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global ownership - all files require review from the repository owner
+* @L3GJ0N @betwo @lschilli
+
+# Core application code - requires review from maintainers
+/src/ @L3GJ0N @betwo @lschilli
+/tests/ @L3GJ0N @betwo @lschilli
+
+# Configuration and build files - requires careful review
+pyproject.toml @L3GJ0N @betwo @lschilli
+uv.lock @L3GJ0N @betwo @lschilli
+.github/ @L3GJ0N @betwo @lschilli
+.gitignore @L3GJ0N @betwo @lschilli
+
+# Documentation - can be reviewed by documentation maintainers
+README.MD @L3GJ0N @betwo @lschilli
+/docs/ @L3GJ0N @betwo @lschilli
+
+# Examples and sample files
+/examples/ @L3GJ0N @betwo @lschilli
+
+# GitHub Actions and CI/CD workflows - requires admin review
+/.github/workflows/ @L3GJ0N @betwo @lschilli

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /examples/downloads/
 /examples/snippets/
 /test_soundboard/
+/wav_files_test/
 
 # Intermediate cut files
 *.cut.m4a


### PR DESCRIPTION
- Add .github/CODEOWNERS to define code review requirements
- Add wav_files_test/ to .gitignore to exclude test output directory
- Set @L3GJ0N as code owner for all files and directories
- Ensure proper review process for core application code, configuration, and CI/CD files