### PR TITLE
Switch from black to ruff formatter only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,4 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
-        language_version: python3
-        args: ["--line-length", "88"]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.4
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Create multiple precisely trimmed audio snippets from YouTube URL
 readme = "README.MD"
 license = {text = "MIT"}
 authors = [
-    { name = "Your Name", email = "your.email@example.com" }
+    { name = "L3GJ0N" }
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -101,7 +101,7 @@ select = [
     "UP",  # pyupgrade
 ]
 ignore = [
-    "E501",  # line too long, handled by black
+    "E501",  # line too long, handled by ruff formatter
     "B008",  # do not perform function calls in argument defaults
     "C901",  # too complex
 ]
@@ -112,6 +112,12 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
 
 # Pytest configuration
 [tool.pytest.ini_options]


### PR DESCRIPTION
- Remove black from pre-commit configuration
- Keep only ruff and ruff-format for consistent tooling
- Update pyproject.toml to use ruff formatter instead of black
- Add [tool.ruff.format] configuration section with sensible defaults
- Clean pre-commit cache to ensure proper application of new config

Benefits:
- Single tool for both linting and formatting (ruff)
- Faster pre-commit hooks
- Consistent formatting rules
- Reduced dependency complexity