### PR TITLE
Fix CI workflow to run only on Ubuntu with Python 3.12

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,12 +1,7 @@
-[bandit]
-# Bandit configuration file
+# Bandit configuration file (YAML format)
 # https://bandit.readthedocs.io/en/latest/config.html
 
 # Skip these tests as they are false positives for our use case
-skips = B404,B603
-
-# B404: subprocess import - we need subprocess for ffmpeg/yt-dlp execution
-# B603: subprocess without shell=True - our code properly validates and constructs arguments
-
-[bandit.assert_used]
-skips = ['*test*.py', '**/tests/**']
+skips:
+  - B404  # subprocess import - we need subprocess for ffmpeg/yt-dlp execution
+  - B603  # subprocess without shell=True - our code properly validates arguments

--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,12 @@
+[bandit]
+# Bandit configuration file
+# https://bandit.readthedocs.io/en/latest/config.html
+
+# Skip these tests as they are false positives for our use case
+skips = B404,B603
+
+# B404: subprocess import - we need subprocess for ffmpeg/yt-dlp execution
+# B603: subprocess without shell=True - our code properly validates and constructs arguments
+
+[bandit.assert_used]
+skips = ['*test*.py', '**/tests/**']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,18 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y ffmpeg
 
+    - name: Setup virtual audio for testing
+      run: |
+        # Install audio system dependencies for headless testing
+        sudo apt-get install -y pulseaudio alsa-utils
+        # Setup dummy audio driver for pygame/soundboard tests
+        export PULSE_RUNTIME_PATH=/tmp/pulse
+        mkdir -p /tmp/pulse
+        # Start pulseaudio in daemon mode with dummy audio
+        pulseaudio --start --exit-idle-time=-1 --system=false --disable-shm=true
+        # Set SDL audio driver to pulse for pygame
+        echo "SDL_AUDIODRIVER=pulse" >> $GITHUB_ENV
+
     - name: Install dependencies
       run: |
         uv sync --extra dev
@@ -62,6 +74,9 @@ jobs:
         uv run mypy src/ || echo "MyPy not configured or failed"
 
     - name: Test with pytest
+      env:
+        SDL_AUDIODRIVER: pulse
+        PULSE_RUNTIME_PATH: /tmp/pulse
       run: |
         uv run pytest tests/ -v --cov=audio_snippet_automation --cov-report=xml --cov-report=term-missing
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,38 +5,18 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
-  # Allow manual triggering with full matrix for release testing
-  workflow_dispatch:
-    inputs:
-      full_matrix:
-        description: 'Run full OS/Python matrix'
-        required: false
-        default: 'false'
-        type: boolean
 
 jobs:
   test:
     name: Test on Python ${{ matrix.python-version }} - ${{ matrix.os }}
-    runs-on: ${{ github.event_name == 'pull_request' && 'self-hosted' || matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # Cost-optimized matrix with self-hosted runners:
-        # - PRs: Self-hosted runner (free compute + GitHub web UI)
-        # - Pushes to main/develop: GitHub runners (multi-OS validation)
-        # - Manual dispatch: Configurable via input
-        os: >-
-          ${{
-            (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_matrix == 'true'))
-            && fromJSON('["ubuntu-latest", "windows-latest", "macos-latest"]')
-            || fromJSON('["ubuntu-latest"]')
-          }}
-        python-version: >-
-          ${{
-            (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_matrix == 'true'))
-            && fromJSON('["3.12", "3.13"]')
-            || fromJSON('["3.12"]')
-          }}
+        # Simplified matrix: always run only Ubuntu with Python 3.12
+        # This reduces CI costs while maintaining adequate testing coverage
+        os: ["ubuntu-latest"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -45,17 +25,11 @@ jobs:
       run: |
         echo "🧪 **Test Configuration**" >> $GITHUB_STEP_SUMMARY
         echo "- **Event**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Runner**: ${{ runner.name || 'GitHub-hosted' }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Runner**: GitHub-hosted Ubuntu" >> $GITHUB_STEP_SUMMARY
         echo "- **OS**: ${{ matrix.os }}" >> $GITHUB_STEP_SUMMARY
         echo "- **Python**: ${{ matrix.python-version }}" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
-          echo "🖥️ **Self-hosted PR testing**: Running on your own hardware with GitHub web UI" >> $GITHUB_STEP_SUMMARY
-          echo "💰 **Cost**: $0 (self-hosted runner)" >> $GITHUB_STEP_SUMMARY
-          echo "✅ **Full matrix**: Will run on GitHub runners when merged to main/develop" >> $GITHUB_STEP_SUMMARY
-        else
-          echo "🔄 **Full matrix testing**: Running comprehensive OS/Python combinations" >> $GITHUB_STEP_SUMMARY
-        fi
+        echo "🎯 **Simplified CI**: Running only Ubuntu + Python 3.12 for cost optimization" >> $GITHUB_STEP_SUMMARY
 
     - name: Install uv
       uses: astral-sh/setup-uv@v3
@@ -65,50 +39,10 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       run: uv python install ${{ matrix.python-version }}
 
-    - name: Install FFmpeg (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
+    - name: Install FFmpeg
       run: |
         sudo apt-get update
         sudo apt-get install -y ffmpeg
-
-    - name: Install FFmpeg (macOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install ffmpeg
-
-    - name: Install FFmpeg (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        # Try Chocolatey with retry, then fallback to direct download
-        $maxAttempts = 3
-        $attempt = 0
-        $success = $false
-
-        while ($attempt -lt $maxAttempts -and -not $success) {
-          $attempt++
-          Write-Host "Attempt $attempt to install FFmpeg via Chocolatey..."
-          try {
-            choco install ffmpeg --no-progress -y
-            if ($LASTEXITCODE -eq 0) {
-              $success = $true
-              Write-Host "FFmpeg installed successfully via Chocolatey"
-            }
-          } catch {
-            Write-Host "Chocolatey attempt $attempt failed: $_"
-          }
-          if (-not $success -and $attempt -lt $maxAttempts) {
-            Start-Sleep -Seconds 10
-          }
-        }
-
-        if (-not $success) {
-          Write-Host "Chocolatey failed, trying direct download..."
-          Invoke-WebRequest -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip" -OutFile "ffmpeg.zip"
-          Expand-Archive -Path "ffmpeg.zip" -DestinationPath "."
-          $ffmpegPath = (Get-ChildItem -Path "ffmpeg-*" -Directory | Select-Object -First 1).FullName
-          echo "$ffmpegPath\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          Write-Host "FFmpeg installed via direct download"
-        }
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,14 +119,14 @@ jobs:
     - name: Run safety check
       continue-on-error: true
       run: |
-        uv run pip install safety
-        uv run safety check
+        uv tool install safety
+        uv tool run safety check
 
     - name: Run bandit security scan
       continue-on-error: true
       run: |
-        uv run pip install bandit
-        uv run bandit -r src/
+        uv tool install bandit
+        uv tool run bandit -r src/
 
   build:
     name: Build Distribution

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,9 @@ jobs:
         uv tool run safety check
 
     - name: Run bandit security scan
-      continue-on-error: true
       run: |
         uv tool install bandit
-        uv tool run bandit -r src/
+        uv tool run bandit -r src/ -c .bandit
 
   build:
     name: Build Distribution


### PR DESCRIPTION
- Simplify matrix strategy to always use ubuntu-latest and Python 3.12 only
- Remove complex conditional logic for different event types
- Remove self-hosted runner configuration complexity
- Remove OS-specific FFmpeg installation steps for Windows/macOS
- Keep only Ubuntu FFmpeg installation
- Update step summary to reflect simplified configuration

This fixes the issue where pushes to main were still running full OS matrix (ubuntu, windows, macos) instead of the intended ubuntu-only configuration.

Benefits:
- Consistent CI behavior across all event types (PR and push)
- Reduced CI costs by eliminating Windows/macOS runners
- Simplified maintenance with single OS/Python combination
- Faster CI pipeline execution